### PR TITLE
Remove GetFileAttributesW for performance

### DIFF
--- a/ext/fenix/file.c
+++ b/ext/fenix/file.c
@@ -354,13 +354,6 @@ fenix_replace_to_long_name(wchar_t **wfullpath, size_t size, int heap) {
 		pos--;
 	}
 
-	/*
-	  Avoid FindFirstFileW over non-existing path.
-	  GetFileAttributesW is faster to check if path doesn't exists.
-	*/
-	if (GetFileAttributesW(*wfullpath) == INVALID_FILE_ATTRIBUTES)
-		return size;
-
 	find_handle = FindFirstFileW(*wfullpath, &find_data);
 	if (find_handle != INVALID_HANDLE_VALUE) {
 		size_t trail_pos = wcslen(*wfullpath);

--- a/ext/fenix/file.c
+++ b/ext/fenix/file.c
@@ -679,17 +679,21 @@ fenix_file_expand_path(int argc, VALUE *argv)
 		} else {
 			wfullpath = wfullpath_buffer;
 		}
+		// wprintf(L"wfullpath: '%s'\n", wfullpath);
 
 
 		/* Calculate the new size and leave the garbage out */
 		// size = wcslen(wfullpath);
 
 		/* Remove any trailing slashes */
-		if (IS_DIR_SEPARATOR_P(wfullpath[size - 1]) && wfullpath[size - 2] != L':') {
+		if (IS_DIR_SEPARATOR_P(wfullpath[size - 1]) &&
+			wfullpath[size - 2] != L':' &&
+			!(size == 2 && IS_DIR_UNC_P(wfullpath))) {
 			// wprintf(L"Removing trailing slash\n");
 			size -= 1;
 			wfullpath[size] = L'\0';
 		}
+		// wprintf(L"wfullpath: '%s'\n", wfullpath);
 
 		/* Remove any trailing dot */
 		if (wfullpath[size - 1] == L'.') {

--- a/spec/fenix/file_spec.rb
+++ b/spec/fenix/file_spec.rb
@@ -106,6 +106,12 @@ describe Fenix::File do
       subject.expand_path('.', "//").must_equal "//"
     end
 
+    it "preserves UNC path root" do
+      subject.expand_path("//").must_equal "//"
+      subject.expand_path("//.").must_equal "//"
+      subject.expand_path("//..").must_equal "//"
+    end
+
     it "converts a pathname which starts with a slash using '//host/share'" do
       subject.expand_path('/foo', "//host/share/bar").must_match %r"\A//host/share/foo\z"i
     end


### PR DESCRIPTION
Thank you for timing result.
I tried rails startup bench with `to_long_name` = 1. Startup is faster if removing GetFileAttributesW at my benchmark.

According to Yura's cached-lp result, expand_path is called against load_path many times. And load_path is existing path. GetFileAttributesW is just overhead for existing path. So removing would be better when cached-lp is not enabled.
