### PR TITLE
Add missing specs related to root slash

### DIFF
--- a/ext/fenix/file.c
+++ b/ext/fenix/file.c
@@ -539,6 +539,17 @@ fenix_file_expand_path(int argc, VALUE *argv)
 		}
 	}
 
+	if (!ignore_dir && wpath_len >= 2 && IS_DIR_UNC_P(wpath)) {
+		/* ignore dir since path has UNC root */
+		ignore_dir = 1;
+		wdir_len = 0;
+	} else if (!ignore_dir && wpath_len >= 1 && IS_DIR_SEPARATOR_P(wpath[0]) &&
+		!dir_drive && !(wdir_len >= 2 && IS_DIR_UNC_P(wdir))) {
+		/* ignore dir since path has root slash and dir doesn't have drive or UNC root */
+		ignore_dir = 1;
+		wdir_len = 0;
+	}
+
 	// wprintf(L"wpath_len: %i\n", wpath_len);
 	// wprintf(L"wdir_len: %i\n", wdir_len);
 	// wprintf(L"whome_len: %i\n", whome_len);

--- a/spec/fenix/file_spec.rb
+++ b/spec/fenix/file_spec.rb
@@ -91,6 +91,18 @@ describe Fenix::File do
       subject.expand_path('/foo', "z:/bar").must_match %r"\Az:/foo\z"i
     end
 
+    it "converts a pathname which starts with a slash ignoring dir" do
+      # This spec is from TestPathname#test_expand_path of test/pathname/test_pathname.rb
+      subject.expand_path('/foo', "/bar").must_match %r"\Ac:/foo\z"i
+      subject.expand_path('/foo', "bar").must_match %r"\Ac:/foo\z"i
+    end
+
+    it "converts a pathname which starts with a slash and UNC pathname" do
+      subject.expand_path('//foo', "//bar").must_equal "//foo"
+      subject.expand_path('/foo', "//bar").must_equal "//bar/foo"
+      subject.expand_path('//foo', "/bar").must_equal "//foo"
+    end
+
     it "converts a dot with UNC dir" do
       subject.expand_path('.', "//").must_equal "//"
     end


### PR DESCRIPTION
I was investigating fenix integration into win32/file.c and found an issue.

TestPathname#test_expand_path failed when I did make test-all. I fixed
it and added some specs.
